### PR TITLE
feat: Add topic restriction configuration for Telegram bot

### DIFF
--- a/example-config.yaml
+++ b/example-config.yaml
@@ -7,6 +7,14 @@ telegram:
     - 123456789
     - 987654321
 
+  # Optional: Restrict bot to specific topics in group chats
+  # Map of chat_id to list of allowed topic IDs. If not set or empty for a chat, all topics are allowed.
+  # Example (bot will only respond in topic 5 and 10 of chat -1001706698345):
+  # allowed_topic_ids:
+  #   -1001706698345:
+  #     - 5
+  #     - 10
+
   # Super admin chat IDs (full access)
   super_admin_ids:
     - 123456789

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -327,6 +327,12 @@ func (b *Bot) withAuth(ctx context.Context, update *models.Update, handler func(
 		return
 	}
 
+	// Check topic restrictions if configured
+	if messageThreadID != 0 && !b.config.IsAllowedTopic(chatID, messageThreadID) {
+		log.Printf("Topic %d not allowed for chat %d", messageThreadID, chatID)
+		return
+	}
+
 	handler(ctx, chatID, messageThreadID, isSuperAdmin, user)
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -50,9 +50,10 @@ type MetricsConfig struct {
 
 // TelegramConfig holds Telegram bot settings
 type TelegramConfig struct {
-	BotToken       string  `mapstructure:"bot_token"`
-	AllowedChatIDs []int64 `mapstructure:"allowed_chat_ids"`
-	SuperAdminIDs  []int64 `mapstructure:"super_admin_ids"`
+	BotToken        string            `mapstructure:"bot_token"`
+	AllowedChatIDs  []int64           `mapstructure:"allowed_chat_ids"`
+	SuperAdminIDs   []int64           `mapstructure:"super_admin_ids"`
+	AllowedTopicIDs map[int64][]int64 `mapstructure:"allowed_topic_ids"` // map[chatID][]topicID - if set, bot only responds in these topics for that chat
 }
 
 // RealDebridConfig holds Real-Debrid API settings
@@ -307,4 +308,21 @@ func (c *Config) IsAllowedChat(chatID int64) bool {
 // IsSuperAdmin checks if a user ID belongs to a super admin
 func (c *Config) IsSuperAdmin(userID int64) bool {
 	return slices.Contains(c.Telegram.SuperAdminIDs, userID)
+}
+
+// IsAllowedTopic checks if the given topic is allowed for the given chat.
+// If AllowedTopicIDs is not configured (nil/empty), it returns true (all topics allowed).
+// If configured, it returns true only if the topicID is in the allowed list for that chat.
+func (c *Config) IsAllowedTopic(chatID int64, topicID int) bool {
+	if c.Telegram.AllowedTopicIDs == nil {
+		return true
+	}
+	allowedTopics, ok := c.Telegram.AllowedTopicIDs[chatID]
+	if !ok {
+		return false // Chat not configured, deny
+	}
+	if len(allowedTopics) == 0 {
+		return true // Empty list means all topics allowed for this chat
+	}
+	return slices.Contains(allowedTopics, int64(topicID))
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -50,10 +50,10 @@ type MetricsConfig struct {
 
 // TelegramConfig holds Telegram bot settings
 type TelegramConfig struct {
-	BotToken        string            `mapstructure:"bot_token"`
-	AllowedChatIDs  []int64           `mapstructure:"allowed_chat_ids"`
-	SuperAdminIDs   []int64           `mapstructure:"super_admin_ids"`
-	AllowedTopicIDs map[int64][]int64 `mapstructure:"allowed_topic_ids"` // map[chatID][]topicID - if set, bot only responds in these topics for that chat
+	BotToken        string             `mapstructure:"bot_token"`
+	AllowedChatIDs  []int64            `mapstructure:"allowed_chat_ids"`
+	SuperAdminIDs   []int64            `mapstructure:"super_admin_ids"`
+	AllowedTopicIDs map[string][]int64 `mapstructure:"allowed_topic_ids"` // map[chatID][]topicID - if set, bot only responds in these topics for that chat
 }
 
 // RealDebridConfig holds Real-Debrid API settings
@@ -311,15 +311,17 @@ func (c *Config) IsSuperAdmin(userID int64) bool {
 }
 
 // IsAllowedTopic checks if the given topic is allowed for the given chat.
-// If AllowedTopicIDs is not configured (nil/empty), it returns true (all topics allowed).
-// If configured, it returns true only if the topicID is in the allowed list for that chat.
+// If AllowedTopicIDs is not configured (nil), it returns true (all topics allowed).
+// If the chat is not in the map, it returns true (topic restriction not configured for this chat).
+// If the chat is configured with an empty list, it returns true (all topics allowed for this chat).
+// If the chat is configured with specific IDs, it returns true only if the topicID is in the list.
 func (c *Config) IsAllowedTopic(chatID int64, topicID int) bool {
 	if c.Telegram.AllowedTopicIDs == nil {
 		return true
 	}
-	allowedTopics, ok := c.Telegram.AllowedTopicIDs[chatID]
+	allowedTopics, ok := c.Telegram.AllowedTopicIDs[fmt.Sprintf("%d", chatID)]
 	if !ok {
-		return false // Chat not configured, deny
+		return true // Chat not in map - topic restriction not configured, allow all
 	}
 	if len(allowedTopics) == 0 {
 		return true // Empty list means all topics allowed for this chat


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Telegram topic allowlisting: admins can optionally specify per-group which thread/topic IDs the bot may operate in. If no list is provided for a chat (or the list is empty), the bot continues to allow all topics in that chat by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->